### PR TITLE
Add pandas DataFrame support and numeric tag aggregation for series

### DIFF
--- a/mnts/utils/dicom_tag_printer.py
+++ b/mnts/utils/dicom_tag_printer.py
@@ -13,11 +13,20 @@ import os
 import re
 import json
 from pathlib import Path
-from typing import List, Dict, Union, Optional
+from typing import List, Dict, Union, Optional, TYPE_CHECKING
 from collections import defaultdict
 from rich.console import Console
 from rich.table import Table
 from rich.logging import RichHandler
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+try:
+    import pandas as pd
+    PANDAS_AVAILABLE = True
+except ImportError:
+    PANDAS_AVAILABLE = False
 
 try:
     import click
@@ -47,18 +56,18 @@ __all__ = ['DicomTagPrinter', 'print_dicom_tags', 'validate_tag_format', 'print_
 
 class DicomTagPrinter:
     """DICOM Tag Printer Class
-    
+
     This class provides functionality to read DICOM files and print specific tags.
     Supports both pydicom and SimpleITK as backend engines.
-    
+
     Args:
         backend (str): Backend engine to use, 'pydicom' or 'sitk' or 'auto'
         logger: Logger instance for logging information
     """
-    
+
     def __init__(self, backend: str = 'auto', logger=None):
         self.logger = logger or MNTSLogger['DicomTagPrinter']
-        
+
         # Select backend
         if backend == 'auto':
             if PYDICOM_AVAILABLE:
@@ -77,16 +86,16 @@ class DicomTagPrinter:
             self.backend = 'sitk'
         else:
             raise ValueError(f"Unsupported backend: {backend}")
-            
+
         self.logger.info(f"Using backend: {self.backend}")
 
     def read_dicom_tag_pydicom(self, file_path: Union[str, Path], tags: List[str]) -> Dict[str, str]:
         """Read DICOM tags using pydicom
-        
+
         Args:
             file_path: DICOM file path
             tags: List of tags to read, format: ['0008|103e', '0010|0020']
-            
+
         Returns:
             Dictionary containing tag values
         """
@@ -123,11 +132,11 @@ class DicomTagPrinter:
 
     def read_dicom_tag_sitk(self, file_path: Union[str, Path], tags: List[str]) -> Dict[str, str]:
         """Read DICOM tags using SimpleITK
-        
+
         Args:
             file_path: DICOM file path
             tags: List of tags to read, format: ['0008|103e', '0010|0020']
-            
+
         Returns:
             Dictionary containing tag values
         """
@@ -157,11 +166,11 @@ class DicomTagPrinter:
 
     def read_dicom_tags(self, file_path: Union[str, Path], tags: List[str]) -> Dict[str, str]:
         """Read DICOM tags (unified interface)
-        
+
         Args:
             file_path: DICOM file path
             tags: List of tags to read
-            
+
         Returns:
             Dictionary containing tag values
         """
@@ -170,21 +179,21 @@ class DicomTagPrinter:
         else:
             return self.read_dicom_tag_sitk(file_path, tags)
 
-    def find_dicom_files(self, input_path: Union[str, Path], recursive: bool = True, 
+    def find_dicom_files(self, input_path: Union[str, Path], recursive: bool = True,
                         max_depth: int = 10) -> List[Path]:
         """Find DICOM files
-        
+
         Args:
             input_path: Input path (file or directory)
             recursive: Whether to search recursively
             max_depth: Maximum search depth
-            
+
         Returns:
             List of DICOM file paths
         """
         input_path = Path(input_path)
         dicom_files = []
-        
+
         if input_path.is_file():
             # Single file
             if self.is_dicom_file(input_path):
@@ -210,15 +219,15 @@ class DicomTagPrinter:
                 for file_path in input_path.iterdir():
                     if file_path.is_file() and self.is_dicom_file(file_path):
                         dicom_files.append(file_path)
-        
+
         return sorted(dicom_files)
 
     def is_dicom_file(self, file_path: Path) -> bool:
         """Check if file is DICOM format
-        
+
         Args:
             file_path: File path
-            
+
         Returns:
             Whether file is DICOM
         """
@@ -226,7 +235,7 @@ class DicomTagPrinter:
             # First check file extension
             if file_path.suffix.lower() in ['.dcm', '.dicom']:
                 return True
-                
+
             # Try to read DICOM header
             if self.backend == 'pydicom' and PYDICOM_AVAILABLE:
                 try:
@@ -244,15 +253,15 @@ class DicomTagPrinter:
                     return False
         except:
             pass
-            
+
         return False
 
     def group_by_series(self, dicom_files: List[Path]) -> Dict[str, List[Path]]:
         """Group DICOM files by series
-        
+
         Args:
             dicom_files: List of DICOM files
-            
+
         Returns:
             Dictionary of file groups keyed by series UID
         """
@@ -264,7 +273,7 @@ class DicomTagPrinter:
                     # Get common directory
                     common_dir = Path(os.path.commonpath([str(f.parent) for f in dicom_files]))
                     series_dict = pydicom_read_series(common_dir, progress_bar=False)
-                    
+
                     # Filter to only include files in our list
                     filtered_dict = {}
                     file_set = set(dicom_files)
@@ -272,14 +281,14 @@ class DicomTagPrinter:
                         filtered_files = [f for f in files if f in file_set]
                         if filtered_files:
                             filtered_dict[series_uid] = filtered_files
-                    
+
                     return filtered_dict
             except Exception as e:
                 self.logger.warning(f"Failed to use pydicom_read_series, using fallback: {e}")
-        
+
         # Fallback method
         series_groups = defaultdict(list)
-        
+
         for file_path in dicom_files:
             try:
                 # Try to get series instance UID
@@ -291,20 +300,109 @@ class DicomTagPrinter:
                     reader.SetFileName(str(file_path))
                     reader.ReadImageInformation()
                     series_uid = reader.GetMetaData('0020|000e') if reader.HasMetaDataKey('0020|000e') else 'Unknown'
-                
+
                 series_groups[series_uid].append(file_path)
-                
+
             except Exception as e:
                 self.logger.warning(f"Cannot read series UID from {file_path}: {e}")
                 series_groups['Unknown'].append(file_path)
-        
+
         return dict(series_groups)
+
+    def _aggregate_series_tags(self, files: List[Path], tags: List[str]) -> Dict[str, str]:
+        """Read all files in a series and aggregate numeric tag values as ranges.
+
+        For each tag:
+        - If all valid values are identical, the single value is shown.
+        - If all valid values are numeric (int or float), the range is shown as
+          ``"min~max"`` (e.g. ``"1~30"``).
+        - Otherwise the representative (first) file's value is used.
+
+        Args:
+            files: All files belonging to a single series.
+            tags: Tags to read.
+
+        Returns:
+            Dict mapping each tag name to its aggregated value string.
+        """
+        all_values: Dict[str, List[str]] = defaultdict(list)
+        for file_path in files:
+            tag_values = self.read_dicom_tags(file_path, tags)
+            for tag, value in tag_values.items():
+                all_values[tag].append(value)
+
+        result: Dict[str, str] = {}
+        for tag in tags:
+            values = all_values.get(tag, [])
+            valid = [v for v in values if v not in ('Missing', 'Error')]
+
+            if not valid:
+                result[tag] = values[0] if values else 'Missing'
+                continue
+
+            # All identical — show the single value
+            if len(set(valid)) == 1:
+                result[tag] = valid[0]
+                continue
+
+            # Attempt numeric range summarisation
+            try:
+                numbers = [float(v) for v in valid]
+                lo, hi = min(numbers), max(numbers)
+
+                def _fmt(n: float) -> str:
+                    return str(int(n)) if n == int(n) else str(n)
+
+                result[tag] = f"{_fmt(lo)}~{_fmt(hi)}"
+            except (ValueError, TypeError):
+                # Non-numeric mixed values — fall back to the representative value
+                result[tag] = valid[0]
+
+        return result
+
+    def build_dataframe(self, results: List[Dict], tags: List[str],
+                        group_by_series: bool) -> 'pd.DataFrame':
+        """Build a unified DataFrame from tag results.
+
+        This is the single source of truth for column structure and ordering used
+        by all output methods (table, CSV, JSON).  Index columns (path / series
+        metadata) come first, followed by the tag columns in the order given by
+        *tags*.
+
+        Args:
+            results: List of result dicts produced by :meth:`print_tags` or
+                :meth:`print_tags_from_json`.
+            tags: Ordered list of tag column names.  May include ``'SubjectID'``
+                when an *id_globber* was applied.
+            group_by_series: When ``True`` the index columns are
+                ``SeriesUID``, ``FileCount``, and ``RepresentativeFile``;
+                otherwise only ``FilePath``.
+
+        Returns:
+            :class:`pandas.DataFrame` with index columns first, followed by tag
+            columns.  Missing values are filled with ``'N/A'``.
+        """
+        if not PANDAS_AVAILABLE:
+            raise ImportError("pandas is required for build_dataframe. Install it with: pip install pandas")
+
+        index_cols = (
+            ['SeriesUID', 'FileCount', 'RepresentativeFile']
+            if group_by_series
+            else ['FilePath']
+        )
+        # Avoid duplicating index columns if they were somehow included in tags
+        tag_cols = [t for t in tags if t not in index_cols]
+        all_cols = index_cols + tag_cols
+
+        rows = [{col: result.get(col, 'N/A') for col in all_cols} for result in results]
+        return pd.DataFrame(rows, columns=all_cols)
 
     def print_tags(self, input_path: Union[str, Path], tags: List[str],
                    recursive: bool = True, group_by_series: bool = True,
                    output_format: str = 'table', max_depth: int = 10,
-                   id_globber: Optional[str] = None) -> None:
-        """Print DICOM tag information
+                   id_globber: Optional[str] = None,
+                   summarize_numeric: bool = False) -> None:
+        """Print DICOM tag information.
 
         Args:
             input_path: Input path
@@ -318,6 +416,11 @@ class DicomTagPrinter:
                 prepended to the output table derived by applying the pattern to
                 the representative file path (series view) or each file path
                 (file view).
+            summarize_numeric: When ``True`` and *group_by_series* is also
+                ``True``, all files in each series are read and numeric tags are
+                summarised as ``"min~max"`` ranges instead of only showing the
+                representative file's value.  Disabled by default because it
+                requires reading every file in the series.
         """
         self.logger.info(f"Processing: {input_path}")
         self.logger.info(f"Tags to read: {tags}")
@@ -341,13 +444,15 @@ class DicomTagPrinter:
             self.logger.info(f"Found {len(series_groups)} series")
 
             for series_uid, files in series_groups.items():
-                representative_file = files[0]
-                tag_values = self.read_dicom_tags(representative_file, tags)
+                if summarize_numeric and len(files) > 1:
+                    tag_values = self._aggregate_series_tags(files, tags)
+                else:
+                    tag_values = self.read_dicom_tags(files[0], tags)
 
                 result = {
                     'SeriesUID': series_uid,
                     'FileCount': len(files),
-                    'RepresentativeFile': str(representative_file),
+                    'RepresentativeFile': str(files[0]),
                     **tag_values
                 }
                 results.append(result)
@@ -365,109 +470,119 @@ class DicomTagPrinter:
             display_tags = self._inject_subject_id(results, id_globber,
                                                     group_by_series, display_tags)
 
-        # Output results
-        self._print_results(results, display_tags, output_format, group_by_series)
+        # Build unified DataFrame and output results
+        df = self.build_dataframe(results, display_tags, group_by_series)
+        self._print_results(df, output_format, group_by_series)
 
-    def _print_results(self, results: List[Dict], tags: List[str], 
-                      output_format: str, group_by_series: bool) -> None:
-        """Print results
-        
+    def _print_results(self, df: 'pd.DataFrame', output_format: str,
+                       group_by_series: bool) -> None:
+        """Dispatch a unified DataFrame to the appropriate output formatter.
+
         Args:
-            results: List of results
-            tags: List of tags
-            output_format: Output format
-            group_by_series: Whether grouped by series
+            df: Unified DataFrame produced by :meth:`build_dataframe`.
+            output_format: One of ``'table'``, ``'csv'``, or ``'json'``.
+            group_by_series: Passed through to :meth:`_print_table` to control
+                column display names for index columns.
         """
         if output_format == 'table':
-            self._print_table(results, tags, group_by_series)
+            self._print_table(df, group_by_series)
         elif output_format == 'csv':
-            self._print_csv(results, tags, group_by_series)
+            self._print_csv(df)
         elif output_format == 'json':
-            self._print_json(results)
+            self._print_json(df)
         else:
             raise ValueError(f"Unsupported output format: {output_format}")
 
-    def _print_table(self, results: List[Dict], tags: List[str], group_by_series: bool) -> None:
-        """Print results in table format using rich"""
-        if not results:
-            self.console.print("[yellow]No results to display[/yellow]")
+    def _print_table(self, df: 'pd.DataFrame', group_by_series: bool) -> None:
+        """Render the unified DataFrame as a rich table.
+
+        Args:
+            df: Unified DataFrame from :meth:`build_dataframe`.
+            group_by_series: Controls whether series-specific index columns
+                (SeriesUID / FileCount / RepresentativeFile) or the file-view
+                index column (FilePath) is shown with its pretty display name.
+        """
+        if df.empty:
+            Console().print("[yellow]No results to display[/yellow]")
             return
 
-        # Create rich table
         table = Table(show_header=True, header_style="bold magenta", show_lines=True)
 
+        # Mapping from DataFrame column names to display names for index columns
         if group_by_series:
-            # Add columns for series view
-            table.add_column("Series UID", style="cyan", no_wrap=False, max_width=30)
-            table.add_column("File Count", style="green", justify="right")
-            table.add_column("Representative File", style="blue", no_wrap=False, max_width=40)
-
-            for tag in tags:
-                table.add_column(f"{tag}", style="yellow", no_wrap=False)
-
-            # Add rows
-            for result in results:
-                row = [
-                    result['SeriesUID'],
-                    str(result['FileCount']),
-                    result['RepresentativeFile']
-                ] + [str(result.get(tag, 'N/A')) for tag in tags]
-                table.add_row(*row)
+            index_display = {
+                'SeriesUID': 'Series UID',
+                'FileCount': 'File Count',
+                'RepresentativeFile': 'Representative File',
+            }
+            index_styles = {
+                'SeriesUID': dict(style="cyan", no_wrap=False, max_width=30),
+                'FileCount': dict(style="green", justify="right"),
+                'RepresentativeFile': dict(style="blue", no_wrap=False, max_width=40),
+            }
+            index_cols = ['SeriesUID', 'FileCount', 'RepresentativeFile']
         else:
-            # Add columns for file view
-            table.add_column("File Path", style="cyan", no_wrap=False, max_width=50)
+            index_display = {'FilePath': 'File Path'}
+            index_styles = {'FilePath': dict(style="cyan", no_wrap=False, max_width=50)}
+            index_cols = ['FilePath']
 
-            for tag in tags:
-                table.add_column(f"{tag}", style="yellow", no_wrap=False)
+        # Add index columns with pretty display names
+        for col in index_cols:
+            if col in df.columns:
+                table.add_column(index_display[col], **index_styles[col])
 
-            # Add rows
-            for result in results:
-                row = [result['FilePath']] + [str(result.get(tag, 'N/A')) for tag in tags]
-                table.add_row(*row)
+        # Add tag / SubjectID columns using the DataFrame column name directly
+        tag_cols = [c for c in df.columns if c not in index_cols]
+        for col in tag_cols:
+            table.add_column(col, style="yellow", no_wrap=False)
 
-        # Get the rich handler's console from logger if available
-        rich_handler = next((h for h in self.logger._logger.handlers if isinstance(h, RichHandler)), None)
+        # Add rows
+        all_cols = [c for c in index_cols if c in df.columns] + tag_cols
+        for _, row in df.iterrows():
+            table.add_row(*[str(row[col]) for col in all_cols])
 
-        if rich_handler:
-            console = rich_handler.console
-        else:
-            # Fallback to default console
-            console = Console()
+        # Resolve console
+        rich_handler = next(
+            (h for h in self.logger._logger.handlers if isinstance(h, RichHandler)),
+            None
+        )
+        console = rich_handler.console if rich_handler else Console()
 
-        # Print table with summary
-        self.logger.info("Printing to rich console.")
+        entity = 'series' if group_by_series else 'files'
         console.print()
         console.print(table)
-        console.print(f"\n[bold green]Total: {len(results)} {'series' if group_by_series else 'files'}[/bold green]")
+        console.print(f"\n[bold green]Total: {len(df)} {entity}[/bold green]")
 
-    def _print_csv(self, results: List[Dict], tags: List[str], group_by_series: bool) -> None:
-        """Print results in CSV format"""
-        if not results:
+    def _print_csv(self, df: 'pd.DataFrame') -> None:
+        """Print the unified DataFrame in CSV format.
+
+        Args:
+            df: Unified DataFrame from :meth:`build_dataframe`.
+        """
+        if df.empty:
             print("# No results to display")
             return
-            
-        if group_by_series:
-            headers = ['SeriesUID', 'FileCount', 'RepresentativeFile'] + tags
-        else:
-            headers = ['FilePath'] + tags
-            
-        # Print CSV header
-        self.logger.info(','.join(headers))
-        
-        # Print data
-        for result in results:
-            row_data = []
-            for header in headers:
-                value = result.get(header, '')
-                # Handle values containing commas
-                if ',' in str(value):
-                    value = f'"{value}"'
-                row_data.append(str(value))
-            self.logger.debug(','.join(row_data))
 
-    def _print_json(self, results: List[Dict]) -> None:
-        """Print results in JSON format"""
-        print(json.dumps(results, ensure_ascii=False, indent=2))
+        # Header
+        print(','.join(df.columns))
+
+        # Rows — quote fields that contain commas
+        for _, row in df.iterrows():
+            fields = []
+            for val in row:
+                val = str(val)
+                if ',' in val:
+                    val = f'"{val}"'
+                fields.append(val)
+            print(','.join(fields))
+
+    def _print_json(self, df: 'pd.DataFrame') -> None:
+        """Print the unified DataFrame in JSON format.
+
+        Args:
+            df: Unified DataFrame from :meth:`build_dataframe`.
+        """
+        print(json.dumps(df.to_dict('records'), ensure_ascii=False, indent=2))
 
     def find_json_files(self, input_path: Union[str, Path], recursive: bool = True,
                         max_depth: int = 10) -> List[Path]:
@@ -624,12 +739,14 @@ class DicomTagPrinter:
                                                     group_by_series=False,
                                                     display_tags=display_tags)
 
-        self._print_results(results, display_tags, output_format, group_by_series=False)
+        # Build unified DataFrame and output results
+        df = self.build_dataframe(results, display_tags, group_by_series=False)
+        self._print_results(df, output_format, group_by_series=False)
 
 
 def print_dicom_tags(input_path: Union[str, Path], tags: List[str], **kwargs) -> None:
     """Convenience function for printing DICOM tags
-    
+
     Args:
         input_path: Input path
         tags: List of tags

--- a/mnts/utils/dicom_tag_printer.py
+++ b/mnts/utils/dicom_tag_printer.py
@@ -13,14 +13,11 @@ import os
 import re
 import json
 from pathlib import Path
-from typing import List, Dict, Union, Optional, TYPE_CHECKING
+from typing import List, Dict, Union, Optional
 from collections import defaultdict
 from rich.console import Console
 from rich.table import Table
 from rich.logging import RichHandler
-
-if TYPE_CHECKING:
-    import pandas as pd
 
 try:
     import pandas as pd
@@ -52,6 +49,23 @@ from .preprocessing import recursive_list_dir
 from ..io.data_formatting import pydicom_read_series
 
 __all__ = ['DicomTagPrinter', 'print_dicom_tags', 'validate_tag_format', 'print_dicom_tags_from_json']
+
+
+def _fmt_number(n: float) -> str:
+    """Format a number, dropping the decimal point for integer-valued floats."""
+    return str(int(n)) if n == int(n) else str(n)
+
+
+# Rich table column styles keyed by DataFrame column name.
+# Columns not listed here get the default tag style.
+_COL_STYLES = {
+    'SubjectID':          dict(style="magenta", no_wrap=True),
+    'SeriesUID':          dict(style="cyan", no_wrap=False, max_width=30),
+    'FileCount':          dict(style="green", justify="right"),
+    'RepresentativeFile': dict(style="blue", no_wrap=False, max_width=40),
+    'FilePath':           dict(style="cyan", no_wrap=False, max_width=50),
+}
+_DEFAULT_TAG_STYLE = dict(style="yellow", no_wrap=False)
 
 
 class DicomTagPrinter:
@@ -89,8 +103,12 @@ class DicomTagPrinter:
 
         self.logger.info(f"Using backend: {self.backend}")
 
+    # ------------------------------------------------------------------
+    # Tag reading
+    # ------------------------------------------------------------------
+
     def read_dicom_tag_pydicom(self, file_path: Union[str, Path], tags: List[str]) -> Dict[str, str]:
-        """Read DICOM tags using pydicom
+        """Read DICOM tags using pydicom.
 
         Args:
             file_path: DICOM file path
@@ -105,18 +123,15 @@ class DicomTagPrinter:
 
             for tag_str in tags:
                 try:
-                    # Parse tag format "0008|103e"
                     group, element = tag_str.split('|')
                     tag = pydicom.tag.Tag(int(group, 16), int(element, 16))
                     try:
-                        # try to get the tag entity
                         tag_str = dictionary_description(tag)
                     except:
                         pass
 
                     if tag in ds:
-                        value = str(ds[tag].value).strip()
-                        result[tag_str] = value
+                        result[tag_str] = str(ds[tag].value).strip()
                     else:
                         result[tag_str] = 'Missing'
 
@@ -131,7 +146,7 @@ class DicomTagPrinter:
             return {tag: 'Error' for tag in tags}
 
     def read_dicom_tag_sitk(self, file_path: Union[str, Path], tags: List[str]) -> Dict[str, str]:
-        """Read DICOM tags using SimpleITK
+        """Read DICOM tags using SimpleITK.
 
         Args:
             file_path: DICOM file path
@@ -150,8 +165,7 @@ class DicomTagPrinter:
             for tag_str in tags:
                 try:
                     if reader.HasMetaDataKey(tag_str):
-                        value = reader.GetMetaData(tag_str).strip()
-                        result[tag_str] = value
+                        result[tag_str] = reader.GetMetaData(tag_str).strip()
                     else:
                         result[tag_str] = 'Missing'
                 except Exception as e:
@@ -165,7 +179,7 @@ class DicomTagPrinter:
             return {tag: 'Error' for tag in tags}
 
     def read_dicom_tags(self, file_path: Union[str, Path], tags: List[str]) -> Dict[str, str]:
-        """Read DICOM tags (unified interface)
+        """Read DICOM tags (unified interface).
 
         Args:
             file_path: DICOM file path
@@ -179,9 +193,13 @@ class DicomTagPrinter:
         else:
             return self.read_dicom_tag_sitk(file_path, tags)
 
+    # ------------------------------------------------------------------
+    # File discovery
+    # ------------------------------------------------------------------
+
     def find_dicom_files(self, input_path: Union[str, Path], recursive: bool = True,
-                        max_depth: int = 10) -> List[Path]:
-        """Find DICOM files
+                         max_depth: int = 10) -> List[Path]:
+        """Find DICOM files.
 
         Args:
             input_path: Input path (file or directory)
@@ -195,13 +213,10 @@ class DicomTagPrinter:
         dicom_files = []
 
         if input_path.is_file():
-            # Single file
             if self.is_dicom_file(input_path):
                 dicom_files.append(input_path)
         elif input_path.is_dir():
-            # Directory
             if recursive:
-                # Use existing recursive_list_dir function when available
                 try:
                     dirs = recursive_list_dir(max_depth, str(input_path))
                     for dir_path in dirs:
@@ -210,12 +225,10 @@ class DicomTagPrinter:
                                 dicom_files.append(file_path)
                 except Exception as e:
                     self.logger.warning(f"Failed to use recursive_list_dir, using standard method: {e}")
-                    # Fallback method
                     for file_path in input_path.rglob('*'):
                         if file_path.is_file() and self.is_dicom_file(file_path):
                             dicom_files.append(file_path)
             else:
-                # Search current directory only
                 for file_path in input_path.iterdir():
                     if file_path.is_file() and self.is_dicom_file(file_path):
                         dicom_files.append(file_path)
@@ -223,7 +236,7 @@ class DicomTagPrinter:
         return sorted(dicom_files)
 
     def is_dicom_file(self, file_path: Path) -> bool:
-        """Check if file is DICOM format
+        """Check if file is DICOM format.
 
         Args:
             file_path: File path
@@ -232,11 +245,9 @@ class DicomTagPrinter:
             Whether file is DICOM
         """
         try:
-            # First check file extension
             if file_path.suffix.lower() in ['.dcm', '.dicom']:
                 return True
 
-            # Try to read DICOM header
             if self.backend == 'pydicom' and PYDICOM_AVAILABLE:
                 try:
                     pydicom.dcmread(file_path, stop_before_pixels=True)
@@ -256,337 +267,9 @@ class DicomTagPrinter:
 
         return False
 
-    def group_by_series(self, dicom_files: List[Path]) -> Dict[str, List[Path]]:
-        """Group DICOM files by series
-
-        Args:
-            dicom_files: List of DICOM files
-
-        Returns:
-            Dictionary of file groups keyed by series UID
-        """
-        # Try to use existing pydicom_read_series function if available and using pydicom
-        if self.backend == 'pydicom' and PYDICOM_AVAILABLE:
-            try:
-                # Get directory containing files
-                if dicom_files:
-                    # Get common directory
-                    common_dir = Path(os.path.commonpath([str(f.parent) for f in dicom_files]))
-                    series_dict = pydicom_read_series(common_dir, progress_bar=False)
-
-                    # Filter to only include files in our list
-                    filtered_dict = {}
-                    file_set = set(dicom_files)
-                    for series_uid, files in series_dict.items():
-                        filtered_files = [f for f in files if f in file_set]
-                        if filtered_files:
-                            filtered_dict[series_uid] = filtered_files
-
-                    return filtered_dict
-            except Exception as e:
-                self.logger.warning(f"Failed to use pydicom_read_series, using fallback: {e}")
-
-        # Fallback method
-        series_groups = defaultdict(list)
-
-        for file_path in dicom_files:
-            try:
-                # Try to get series instance UID
-                if self.backend == 'pydicom':
-                    ds = pydicom.dcmread(file_path, stop_before_pixels=True)
-                    series_uid = getattr(ds, 'SeriesInstanceUID', 'Unknown')
-                else:
-                    reader = sitk.ImageFileReader()
-                    reader.SetFileName(str(file_path))
-                    reader.ReadImageInformation()
-                    series_uid = reader.GetMetaData('0020|000e') if reader.HasMetaDataKey('0020|000e') else 'Unknown'
-
-                series_groups[series_uid].append(file_path)
-
-            except Exception as e:
-                self.logger.warning(f"Cannot read series UID from {file_path}: {e}")
-                series_groups['Unknown'].append(file_path)
-
-        return dict(series_groups)
-
-    def _aggregate_series_tags(self, files: List[Path], tags: List[str]) -> Dict[str, str]:
-        """Read all files in a series and aggregate numeric tag values as ranges.
-
-        For each tag:
-        - If all valid values are identical, the single value is shown.
-        - If all valid values are numeric (int or float), the range is shown as
-          ``"min~max"`` (e.g. ``"1~30"``).
-        - Otherwise the representative (first) file's value is used.
-
-        Args:
-            files: All files belonging to a single series.
-            tags: Tags to read.
-
-        Returns:
-            Dict mapping each tag name to its aggregated value string.
-        """
-        all_values: Dict[str, List[str]] = defaultdict(list)
-        for file_path in files:
-            tag_values = self.read_dicom_tags(file_path, tags)
-            for tag, value in tag_values.items():
-                all_values[tag].append(value)
-
-        result: Dict[str, str] = {}
-        for tag in tags:
-            values = all_values.get(tag, [])
-            valid = [v for v in values if v not in ('Missing', 'Error')]
-
-            if not valid:
-                result[tag] = values[0] if values else 'Missing'
-                continue
-
-            # All identical — show the single value
-            if len(set(valid)) == 1:
-                result[tag] = valid[0]
-                continue
-
-            # Attempt numeric range summarisation
-            try:
-                numbers = [float(v) for v in valid]
-                lo, hi = min(numbers), max(numbers)
-
-                def _fmt(n: float) -> str:
-                    return str(int(n)) if n == int(n) else str(n)
-
-                result[tag] = f"{_fmt(lo)}~{_fmt(hi)}"
-            except (ValueError, TypeError):
-                # Non-numeric mixed values — fall back to the representative value
-                result[tag] = valid[0]
-
-        return result
-
-    def build_dataframe(self, results: List[Dict], tags: List[str],
-                        group_by_series: bool) -> 'pd.DataFrame':
-        """Build a unified DataFrame from tag results.
-
-        This is the single source of truth for column structure and ordering used
-        by all output methods (table, CSV, JSON).  Index columns (path / series
-        metadata) come first, followed by the tag columns in the order given by
-        *tags*.
-
-        Args:
-            results: List of result dicts produced by :meth:`print_tags` or
-                :meth:`print_tags_from_json`.
-            tags: Ordered list of tag column names.  May include ``'SubjectID'``
-                when an *id_globber* was applied.
-            group_by_series: When ``True`` the index columns are
-                ``SeriesUID``, ``FileCount``, and ``RepresentativeFile``;
-                otherwise only ``FilePath``.
-
-        Returns:
-            :class:`pandas.DataFrame` with index columns first, followed by tag
-            columns.  Missing values are filled with ``'N/A'``.
-        """
-        if not PANDAS_AVAILABLE:
-            raise ImportError("pandas is required for build_dataframe. Install it with: pip install pandas")
-
-        index_cols = (
-            ['SeriesUID', 'FileCount', 'RepresentativeFile']
-            if group_by_series
-            else ['FilePath']
-        )
-        # Avoid duplicating index columns if they were somehow included in tags
-        tag_cols = [t for t in tags if t not in index_cols]
-        all_cols = index_cols + tag_cols
-
-        rows = [{col: result.get(col, 'N/A') for col in all_cols} for result in results]
-        return pd.DataFrame(rows, columns=all_cols)
-
-    def print_tags(self, input_path: Union[str, Path], tags: List[str],
-                   recursive: bool = True, group_by_series: bool = True,
-                   output_format: str = 'table', max_depth: int = 10,
-                   id_globber: Optional[str] = None,
-                   summarize_numeric: bool = False) -> None:
-        """Print DICOM tag information.
-
-        Args:
-            input_path: Input path
-            tags: List of tags to print
-            recursive: Whether to search recursively
-            group_by_series: Whether to group by series
-            output_format: Output format ('table', 'csv', 'json')
-            max_depth: Maximum search depth
-            id_globber: Optional regex pattern to extract a subject/case ID from
-                each file path.  When supplied, a ``SubjectID`` column is
-                prepended to the output table derived by applying the pattern to
-                the representative file path (series view) or each file path
-                (file view).
-            summarize_numeric: When ``True`` and *group_by_series* is also
-                ``True``, all files in each series are read and numeric tags are
-                summarised as ``"min~max"`` ranges instead of only showing the
-                representative file's value.  Disabled by default because it
-                requires reading every file in the series.
-        """
-        self.logger.info(f"Processing: {input_path}")
-        self.logger.info(f"Tags to read: {tags}")
-
-        # Find DICOM files
-        dicom_files = self.find_dicom_files(input_path, recursive, max_depth)
-
-        if not dicom_files:
-            self.logger.warning("No DICOM files found")
-            return
-
-        self.logger.info(f"Found {len(dicom_files)} DICOM files")
-
-        # Read tag information
-        results = []
-        display_tags = list(tags)
-
-        if group_by_series:
-            # Group by series
-            series_groups = self.group_by_series(dicom_files)
-            self.logger.info(f"Found {len(series_groups)} series")
-
-            for series_uid, files in series_groups.items():
-                if summarize_numeric and len(files) > 1:
-                    tag_values = self._aggregate_series_tags(files, tags)
-                else:
-                    tag_values = self.read_dicom_tags(files[0], tags)
-
-                result = {
-                    'SeriesUID': series_uid,
-                    'FileCount': len(files),
-                    'RepresentativeFile': str(files[0]),
-                    **tag_values
-                }
-                results.append(result)
-        else:
-            # Process each file individually
-            for file_path in dicom_files:
-                tag_values = self.read_dicom_tags(file_path, tags)
-                result = {
-                    'FilePath': str(file_path),
-                    **tag_values
-                }
-                results.append(result)
-
-        if id_globber:
-            display_tags = self._inject_subject_id(results, id_globber,
-                                                    group_by_series, display_tags)
-
-        # Build unified DataFrame and output results
-        df = self.build_dataframe(results, display_tags, group_by_series)
-        self._print_results(df, output_format, group_by_series)
-
-    def _print_results(self, df: 'pd.DataFrame', output_format: str,
-                       group_by_series: bool) -> None:
-        """Dispatch a unified DataFrame to the appropriate output formatter.
-
-        Args:
-            df: Unified DataFrame produced by :meth:`build_dataframe`.
-            output_format: One of ``'table'``, ``'csv'``, or ``'json'``.
-            group_by_series: Passed through to :meth:`_print_table` to control
-                column display names for index columns.
-        """
-        if output_format == 'table':
-            self._print_table(df, group_by_series)
-        elif output_format == 'csv':
-            self._print_csv(df)
-        elif output_format == 'json':
-            self._print_json(df)
-        else:
-            raise ValueError(f"Unsupported output format: {output_format}")
-
-    def _print_table(self, df: 'pd.DataFrame', group_by_series: bool) -> None:
-        """Render the unified DataFrame as a rich table.
-
-        Args:
-            df: Unified DataFrame from :meth:`build_dataframe`.
-            group_by_series: Controls whether series-specific index columns
-                (SeriesUID / FileCount / RepresentativeFile) or the file-view
-                index column (FilePath) is shown with its pretty display name.
-        """
-        if df.empty:
-            Console().print("[yellow]No results to display[/yellow]")
-            return
-
-        table = Table(show_header=True, header_style="bold magenta", show_lines=True)
-
-        # Mapping from DataFrame column names to display names for index columns
-        if group_by_series:
-            index_display = {
-                'SeriesUID': 'Series UID',
-                'FileCount': 'File Count',
-                'RepresentativeFile': 'Representative File',
-            }
-            index_styles = {
-                'SeriesUID': dict(style="cyan", no_wrap=False, max_width=30),
-                'FileCount': dict(style="green", justify="right"),
-                'RepresentativeFile': dict(style="blue", no_wrap=False, max_width=40),
-            }
-            index_cols = ['SeriesUID', 'FileCount', 'RepresentativeFile']
-        else:
-            index_display = {'FilePath': 'File Path'}
-            index_styles = {'FilePath': dict(style="cyan", no_wrap=False, max_width=50)}
-            index_cols = ['FilePath']
-
-        # Add index columns with pretty display names
-        for col in index_cols:
-            if col in df.columns:
-                table.add_column(index_display[col], **index_styles[col])
-
-        # Add tag / SubjectID columns using the DataFrame column name directly
-        tag_cols = [c for c in df.columns if c not in index_cols]
-        for col in tag_cols:
-            table.add_column(col, style="yellow", no_wrap=False)
-
-        # Add rows
-        all_cols = [c for c in index_cols if c in df.columns] + tag_cols
-        for _, row in df.iterrows():
-            table.add_row(*[str(row[col]) for col in all_cols])
-
-        # Resolve console
-        rich_handler = next(
-            (h for h in self.logger._logger.handlers if isinstance(h, RichHandler)),
-            None
-        )
-        console = rich_handler.console if rich_handler else Console()
-
-        entity = 'series' if group_by_series else 'files'
-        console.print()
-        console.print(table)
-        console.print(f"\n[bold green]Total: {len(df)} {entity}[/bold green]")
-
-    def _print_csv(self, df: 'pd.DataFrame') -> None:
-        """Print the unified DataFrame in CSV format.
-
-        Args:
-            df: Unified DataFrame from :meth:`build_dataframe`.
-        """
-        if df.empty:
-            print("# No results to display")
-            return
-
-        # Header
-        print(','.join(df.columns))
-
-        # Rows — quote fields that contain commas
-        for _, row in df.iterrows():
-            fields = []
-            for val in row:
-                val = str(val)
-                if ',' in val:
-                    val = f'"{val}"'
-                fields.append(val)
-            print(','.join(fields))
-
-    def _print_json(self, df: 'pd.DataFrame') -> None:
-        """Print the unified DataFrame in JSON format.
-
-        Args:
-            df: Unified DataFrame from :meth:`build_dataframe`.
-        """
-        print(json.dumps(df.to_dict('records'), ensure_ascii=False, indent=2))
-
     def find_json_files(self, input_path: Union[str, Path], recursive: bool = True,
                         max_depth: int = 10) -> List[Path]:
-        """Find .json files in a directory
+        """Find .json files in a directory.
 
         Args:
             input_path: Input path (file or directory)
@@ -620,8 +303,107 @@ class DicomTagPrinter:
 
         return sorted(json_files)
 
+    # ------------------------------------------------------------------
+    # Grouping & aggregation
+    # ------------------------------------------------------------------
+
+    def group_by_series(self, dicom_files: List[Path]) -> Dict[str, List[Path]]:
+        """Group DICOM files by series.
+
+        Args:
+            dicom_files: List of DICOM files
+
+        Returns:
+            Dictionary of file groups keyed by series UID
+        """
+        if self.backend == 'pydicom' and PYDICOM_AVAILABLE:
+            try:
+                if dicom_files:
+                    common_dir = Path(os.path.commonpath([str(f.parent) for f in dicom_files]))
+                    series_dict = pydicom_read_series(common_dir, progress_bar=False)
+
+                    filtered_dict = {}
+                    file_set = set(dicom_files)
+                    for series_uid, files in series_dict.items():
+                        filtered_files = [f for f in files if f in file_set]
+                        if filtered_files:
+                            filtered_dict[series_uid] = filtered_files
+
+                    return filtered_dict
+            except Exception as e:
+                self.logger.warning(f"Failed to use pydicom_read_series, using fallback: {e}")
+
+        series_groups = defaultdict(list)
+
+        for file_path in dicom_files:
+            try:
+                if self.backend == 'pydicom':
+                    ds = pydicom.dcmread(file_path, stop_before_pixels=True)
+                    series_uid = getattr(ds, 'SeriesInstanceUID', 'Unknown')
+                else:
+                    reader = sitk.ImageFileReader()
+                    reader.SetFileName(str(file_path))
+                    reader.ReadImageInformation()
+                    series_uid = reader.GetMetaData('0020|000e') if reader.HasMetaDataKey('0020|000e') else 'Unknown'
+
+                series_groups[series_uid].append(file_path)
+
+            except Exception as e:
+                self.logger.warning(f"Cannot read series UID from {file_path}: {e}")
+                series_groups['Unknown'].append(file_path)
+
+        return dict(series_groups)
+
+    def _aggregate_series_tags(self, files: List[Path], tags: List[str]) -> Dict[str, str]:
+        """Read all files in a series and aggregate numeric tag values as ranges.
+
+        For each tag:
+
+        - If all valid values are identical, the single value is shown.
+        - If all valid values are numeric (int or float), the range is shown as
+          ``"min~max"`` (e.g. ``"1~30"``).
+        - Otherwise the representative (first) file's value is used.
+
+        Args:
+            files: All files belonging to a single series.
+            tags: Tags to read.
+
+        Returns:
+            Dict mapping each tag name to its aggregated value string.
+        """
+        all_values: Dict[str, List[str]] = defaultdict(list)
+        for file_path in files:
+            tag_values = self.read_dicom_tags(file_path, tags)
+            for tag, value in tag_values.items():
+                all_values[tag].append(value)
+
+        result: Dict[str, str] = {}
+        for tag in tags:
+            values = all_values.get(tag, [])
+            valid = [v for v in values if v not in ('Missing', 'Error')]
+
+            if not valid:
+                result[tag] = values[0] if values else 'Missing'
+                continue
+
+            if len(set(valid)) == 1:
+                result[tag] = valid[0]
+                continue
+
+            try:
+                numbers = [float(v) for v in valid]
+                result[tag] = f"{_fmt_number(min(numbers))}~{_fmt_number(max(numbers))}"
+            except (ValueError, TypeError):
+                result[tag] = valid[0]
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Tag reading helpers
+    # ------------------------------------------------------------------
+
     def read_json_tags(self, file_path: Union[str, Path], tags: Optional[List[str]] = None) -> Dict[str, str]:
-        """Read DICOM tags from a JSON file containing key-value pairs
+        """Read DICOM tags from a JSON file containing key-value pairs.
 
         The JSON file is expected to contain DICOM tags as keys in the format
         ``"XXXX|XXXX"`` (e.g. ``"0008|103e"``) with their string values.
@@ -645,40 +427,31 @@ class DicomTagPrinter:
             self.logger.error(f"Expected a JSON object in {file_path}, got {type(data).__name__}")
             return {tag: 'Error' for tag in (tags or [])}
 
-        # Strip whitespace from values
         data = {k: str(v).strip() for k, v in data.items()}
 
         if not tags:
             return data
 
-        result = {}
-        for tag_str in tags:
-            if tag_str in data:
-                result[tag_str] = data[tag_str]
-            else:
-                result[tag_str] = 'Missing'
-        return result
+        return {t: data.get(t, 'Missing') for t in tags}
 
-    def _inject_subject_id(self, results: List[Dict], id_globber: str,
-                           group_by_series: bool, display_tags: List[str]) -> List[str]:
-        """Extract a subject ID from each result's file path and store it in the
-        result dict under the key ``'SubjectID'``.
+    # ------------------------------------------------------------------
+    # Subject ID extraction
+    # ------------------------------------------------------------------
 
-        The extracted ID is prepended to *display_tags* so it appears as the
-        first data column after the path column.
+    @staticmethod
+    def _inject_subject_id(results: List[Dict], id_globber: str,
+                           path_key: str) -> None:
+        """Extract a subject ID from each result's file path.
+
+        Mutates *results* in-place, adding a ``'SubjectID'`` key.
 
         Args:
-            results: Result dicts to mutate in-place.
-            id_globber: Regex pattern whose first match group (or full match if
-                no groups) is used as the subject ID.
-            group_by_series: When True, the path key is ``'RepresentativeFile'``,
-                otherwise ``'FilePath'``.
-            display_tags: Current list of tags to display.
-
-        Returns:
-            Updated display_tags with ``'SubjectID'`` prepended.
+            results: Result dicts to mutate.
+            id_globber: Regex pattern whose first capture group (or full match
+                if no groups) is used as the subject ID.
+            path_key: Key in each result dict that holds the file path
+                (``'FilePath'`` or ``'RepresentativeFile'``).
         """
-        path_key = 'RepresentativeFile' if group_by_series else 'FilePath'
         for result in results:
             path_str = result.get(path_key, '')
             mo = re.search(id_globber, Path(path_str).name)
@@ -686,12 +459,128 @@ class DicomTagPrinter:
                 result['SubjectID'] = mo.group(1) if mo.lastindex else mo.group()
             else:
                 result['SubjectID'] = 'N/A'
-        return ['SubjectID'] + display_tags
 
-    def print_tags_from_json(self, input_path: Union[str, Path], tags: Optional[List[str]] = None,
+    # ------------------------------------------------------------------
+    # Unified DataFrame construction
+    # ------------------------------------------------------------------
+
+    def build_dataframe(self, results: List[Dict], tags: List[str],
+                        group_by_series: bool) -> 'pd.DataFrame':
+        """Build a unified DataFrame from tag results.
+
+        This is the single source of truth for column structure and ordering used
+        by all output methods (table, CSV, JSON).
+
+        When a ``'SubjectID'`` key is present in *results* (i.e. an *id_globber*
+        was applied), it replaces the raw path / series UID column as the primary
+        index column.  The column layout becomes:
+
+        - **File view with globber**: ``SubjectID | tag1 | tag2 | …``
+        - **Series view with globber**: ``SubjectID | FileCount | tag1 | …``
+        - **File view (no globber)**: ``FilePath | tag1 | tag2 | …``
+        - **Series view (no globber)**: ``SeriesUID | FileCount | RepresentativeFile | tag1 | …``
+
+        Args:
+            results: List of result dicts.
+            tags: Ordered list of DICOM tag column names.
+            group_by_series: Whether results are grouped by series.
+
+        Returns:
+            :class:`pandas.DataFrame` with index columns first, followed by tag
+            columns.  Missing values are filled with ``'N/A'``.
+        """
+        if not PANDAS_AVAILABLE:
+            raise ImportError("pandas is required for build_dataframe. "
+                              "Install it with: pip install pandas")
+
+        has_subject_id = results and 'SubjectID' in results[0]
+
+        if has_subject_id:
+            index_cols = ['SubjectID', 'FileCount'] if group_by_series else ['SubjectID']
+        elif group_by_series:
+            index_cols = ['SeriesUID', 'FileCount', 'RepresentativeFile']
+        else:
+            index_cols = ['FilePath']
+
+        tag_cols = [t for t in tags if t not in index_cols]
+        all_cols = index_cols + tag_cols
+
+        rows = [{col: result.get(col, 'N/A') for col in all_cols} for result in results]
+        return pd.DataFrame(rows, columns=all_cols)
+
+    # ------------------------------------------------------------------
+    # Public entry points
+    # ------------------------------------------------------------------
+
+    def print_tags(self, input_path: Union[str, Path], tags: List[str],
+                   recursive: bool = True, group_by_series: bool = True,
+                   output_format: str = 'table', max_depth: int = 10,
+                   id_globber: Optional[str] = None,
+                   summarize_numeric: bool = False) -> None:
+        """Print DICOM tag information.
+
+        Args:
+            input_path: Input path
+            tags: List of tags to print
+            recursive: Whether to search recursively
+            group_by_series: Whether to group by series
+            output_format: Output format ('table', 'csv', 'json')
+            max_depth: Maximum search depth
+            id_globber: Optional regex pattern to extract a subject/case ID from
+                each file path.  When supplied, ``SubjectID`` replaces the file
+                path or series UID as the primary index column.
+            summarize_numeric: When ``True`` and *group_by_series* is also
+                ``True``, all files in each series are read and numeric tags are
+                summarised as ``"min~max"`` ranges instead of only showing the
+                representative file's value.
+        """
+        self.logger.info(f"Processing: {input_path}")
+        self.logger.info(f"Tags to read: {tags}")
+
+        dicom_files = self.find_dicom_files(input_path, recursive, max_depth)
+
+        if not dicom_files:
+            self.logger.warning("No DICOM files found")
+            return
+
+        self.logger.info(f"Found {len(dicom_files)} DICOM files")
+
+        results = []
+
+        if group_by_series:
+            series_groups = self.group_by_series(dicom_files)
+            self.logger.info(f"Found {len(series_groups)} series")
+
+            for series_uid, files in series_groups.items():
+                if summarize_numeric and len(files) > 1:
+                    tag_values = self._aggregate_series_tags(files, tags)
+                else:
+                    tag_values = self.read_dicom_tags(files[0], tags)
+
+                results.append({
+                    'SeriesUID': series_uid,
+                    'FileCount': len(files),
+                    'RepresentativeFile': str(files[0]),
+                    **tag_values,
+                })
+        else:
+            for file_path in dicom_files:
+                tag_values = self.read_dicom_tags(file_path, tags)
+                results.append({'FilePath': str(file_path), **tag_values})
+
+        if id_globber:
+            path_key = 'RepresentativeFile' if group_by_series else 'FilePath'
+            self._inject_subject_id(results, id_globber, path_key)
+
+        df = self.build_dataframe(results, tags, group_by_series)
+        self._print_results(df, output_format)
+
+    def print_tags_from_json(self, input_path: Union[str, Path],
+                             tags: Optional[List[str]] = None,
                              recursive: bool = True, output_format: str = 'table',
-                             max_depth: int = 10, id_globber: Optional[str] = None) -> None:
-        """Print DICOM tag information sourced from a directory of JSON files
+                             max_depth: int = 10,
+                             id_globber: Optional[str] = None) -> None:
+        """Print DICOM tag information sourced from a directory of JSON files.
 
         Each JSON file in *input_path* is treated as one entry (typically one
         series) and must contain DICOM tags as ``"XXXX|XXXX": "value"`` pairs.
@@ -704,8 +593,8 @@ class DicomTagPrinter:
             output_format: Output format (``'table'``, ``'csv'``, or ``'json'``)
             max_depth: Maximum directory search depth
             id_globber: Optional regex pattern to extract a subject/case ID from
-                each JSON file's name.  When supplied, a ``SubjectID`` column is
-                prepended to the output.
+                each JSON file's name.  When supplied, ``SubjectID`` replaces the
+                file path as the primary index column.
         """
         self.logger.info(f"Processing JSON source: {input_path}")
 
@@ -723,29 +612,87 @@ class DicomTagPrinter:
         for file_path in json_files:
             tag_values = self.read_json_tags(file_path, effective_tags)
 
-            # On first file, if no tags were specified derive column set from file
             if effective_tags is None:
                 effective_tags = list(tag_values.keys())
 
-            result = {
-                'FilePath': str(file_path),
-                **tag_values
-            }
-            results.append(result)
+            results.append({'FilePath': str(file_path), **tag_values})
 
-        display_tags = list(effective_tags or [])
         if id_globber:
-            display_tags = self._inject_subject_id(results, id_globber,
-                                                    group_by_series=False,
-                                                    display_tags=display_tags)
+            self._inject_subject_id(results, id_globber, path_key='FilePath')
 
-        # Build unified DataFrame and output results
-        df = self.build_dataframe(results, display_tags, group_by_series=False)
-        self._print_results(df, output_format, group_by_series=False)
+        df = self.build_dataframe(results, effective_tags or [], group_by_series=False)
+        self._print_results(df, output_format)
 
+    # ------------------------------------------------------------------
+    # Output formatting
+    # ------------------------------------------------------------------
+
+    def _print_results(self, df: 'pd.DataFrame', output_format: str) -> None:
+        """Dispatch the unified DataFrame to the appropriate output formatter."""
+        if output_format == 'table':
+            self._print_table(df)
+        elif output_format == 'csv':
+            self._print_csv(df)
+        elif output_format == 'json':
+            self._print_json(df)
+        else:
+            raise ValueError(f"Unsupported output format: {output_format}")
+
+    def _print_table(self, df: 'pd.DataFrame') -> None:
+        """Render the unified DataFrame as a rich table."""
+        if df.empty:
+            Console().print("[yellow]No results to display[/yellow]")
+            return
+
+        table = Table(show_header=True, header_style="bold magenta", show_lines=True)
+
+        for col in df.columns:
+            style = _COL_STYLES.get(col, _DEFAULT_TAG_STYLE)
+            table.add_column(col, **style)
+
+        for _, row in df.iterrows():
+            table.add_row(*[str(v) for v in row])
+
+        # Resolve console from logger's RichHandler if available
+        rich_handler = next(
+            (h for h in self.logger._logger.handlers if isinstance(h, RichHandler)),
+            None,
+        )
+        console = rich_handler.console if rich_handler else Console()
+
+        entity = 'series' if 'FileCount' in df.columns else 'files'
+        console.print()
+        console.print(table)
+        console.print(f"\n[bold green]Total: {len(df)} {entity}[/bold green]")
+
+    def _print_csv(self, df: 'pd.DataFrame') -> None:
+        """Print the unified DataFrame in CSV format."""
+        if df.empty:
+            print("# No results to display")
+            return
+
+        print(','.join(df.columns))
+
+        for _, row in df.iterrows():
+            fields = []
+            for val in row:
+                val = str(val)
+                if ',' in val:
+                    val = f'"{val}"'
+                fields.append(val)
+            print(','.join(fields))
+
+    def _print_json(self, df: 'pd.DataFrame') -> None:
+        """Print the unified DataFrame in JSON format."""
+        print(json.dumps(df.to_dict('records'), ensure_ascii=False, indent=2))
+
+
+# ------------------------------------------------------------------
+# Convenience functions
+# ------------------------------------------------------------------
 
 def print_dicom_tags(input_path: Union[str, Path], tags: List[str], **kwargs) -> None:
-    """Convenience function for printing DICOM tags
+    """Convenience function for printing DICOM tags.
 
     Args:
         input_path: Input path
@@ -756,9 +703,10 @@ def print_dicom_tags(input_path: Union[str, Path], tags: List[str], **kwargs) ->
     printer.print_tags(input_path, tags, **kwargs)
 
 
-def print_dicom_tags_from_json(input_path: Union[str, Path], tags: Optional[List[str]] = None,
+def print_dicom_tags_from_json(input_path: Union[str, Path],
+                               tags: Optional[List[str]] = None,
                                **kwargs) -> None:
-    """Convenience function for printing DICOM tags sourced from JSON files
+    """Convenience function for printing DICOM tags sourced from JSON files.
 
     Args:
         input_path: Path to a JSON file or directory of JSON files

--- a/mnts/utils/dicom_tag_printer.py
+++ b/mnts/utils/dicom_tag_printer.py
@@ -82,7 +82,6 @@ class DicomTagPrinter:
     def __init__(self, backend: str = 'auto', logger=None):
         self.logger = logger or MNTSLogger['DicomTagPrinter']
 
-        # Select backend
         if backend == 'auto':
             if PYDICOM_AVAILABLE:
                 self.backend = 'pydicom'
@@ -115,20 +114,16 @@ class DicomTagPrinter:
             tags: List of tags to read, format: ['0008|103e', '0010|0020']
 
         Returns:
-            Dictionary containing tag values
+            Dictionary mapping raw tag strings to their values.
         """
         try:
-            ds = pydicom.dcmread(file_path, force=True)
+            ds = pydicom.dcmread(file_path, stop_before_pixels=True, force=True)
             result = {}
 
             for tag_str in tags:
                 try:
                     group, element = tag_str.split('|')
                     tag = pydicom.tag.Tag(int(group, 16), int(element, 16))
-                    try:
-                        tag_str = dictionary_description(tag)
-                    except:
-                        pass
 
                     if tag in ds:
                         result[tag_str] = str(ds[tag].value).strip()
@@ -153,7 +148,7 @@ class DicomTagPrinter:
             tags: List of tags to read, format: ['0008|103e', '0010|0020']
 
         Returns:
-            Dictionary containing tag values
+            Dictionary mapping raw tag strings to their values.
         """
         try:
             reader = sitk.ImageFileReader()
@@ -186,7 +181,7 @@ class DicomTagPrinter:
             tags: List of tags to read
 
         Returns:
-            Dictionary containing tag values
+            Dictionary mapping raw tag strings to their values.
         """
         if self.backend == 'pydicom':
             return self.read_dicom_tag_pydicom(file_path, tags)
@@ -196,6 +191,51 @@ class DicomTagPrinter:
     # ------------------------------------------------------------------
     # File discovery
     # ------------------------------------------------------------------
+
+    def _find_files(self, input_path: Union[str, Path], predicate,
+                    glob_pattern: str, recursive: bool, max_depth: int) -> List[Path]:
+        """Generic file finder with recursive_list_dir and rglob fallback.
+
+        Args:
+            input_path: File or directory to search.
+            predicate: Callable[[Path], bool] — returns True for files to include.
+            glob_pattern: Pattern passed to Path.glob() when iterating
+                directories returned by recursive_list_dir (e.g. ``'*'`` or
+                ``'*.json'``).
+            recursive: Whether to descend into subdirectories.
+            max_depth: Maximum depth passed to recursive_list_dir.
+
+        Returns:
+            Sorted list of matching file paths.
+        """
+        input_path = Path(input_path)
+        found = []
+
+        if input_path.is_file():
+            if predicate(input_path):
+                found.append(input_path)
+        elif input_path.is_dir():
+            if recursive:
+                try:
+                    # recursive_list_dir returns every directory that has files
+                    # directly inside it; use non-recursive glob on each to
+                    # avoid double-counting files in nested directories.
+                    dirs = recursive_list_dir(max_depth, str(input_path))
+                    for dir_path in dirs:
+                        for fp in Path(dir_path).glob(glob_pattern):
+                            if fp.is_file() and predicate(fp):
+                                found.append(fp)
+                except Exception as e:
+                    self.logger.warning(f"Failed to use recursive_list_dir, using rglob: {e}")
+                    for fp in input_path.rglob(glob_pattern):
+                        if fp.is_file() and predicate(fp):
+                            found.append(fp)
+            else:
+                for fp in input_path.iterdir():
+                    if fp.is_file() and predicate(fp):
+                        found.append(fp)
+
+        return sorted(found)
 
     def find_dicom_files(self, input_path: Union[str, Path], recursive: bool = True,
                          max_depth: int = 10) -> List[Path]:
@@ -209,31 +249,7 @@ class DicomTagPrinter:
         Returns:
             List of DICOM file paths
         """
-        input_path = Path(input_path)
-        dicom_files = []
-
-        if input_path.is_file():
-            if self.is_dicom_file(input_path):
-                dicom_files.append(input_path)
-        elif input_path.is_dir():
-            if recursive:
-                try:
-                    dirs = recursive_list_dir(max_depth, str(input_path))
-                    for dir_path in dirs:
-                        for file_path in Path(dir_path).rglob('*'):
-                            if file_path.is_file() and self.is_dicom_file(file_path):
-                                dicom_files.append(file_path)
-                except Exception as e:
-                    self.logger.warning(f"Failed to use recursive_list_dir, using standard method: {e}")
-                    for file_path in input_path.rglob('*'):
-                        if file_path.is_file() and self.is_dicom_file(file_path):
-                            dicom_files.append(file_path)
-            else:
-                for file_path in input_path.iterdir():
-                    if file_path.is_file() and self.is_dicom_file(file_path):
-                        dicom_files.append(file_path)
-
-        return sorted(dicom_files)
+        return self._find_files(input_path, self.is_dicom_file, '*', recursive, max_depth)
 
     def is_dicom_file(self, file_path: Path) -> bool:
         """Check if file is DICOM format.
@@ -252,7 +268,7 @@ class DicomTagPrinter:
                 try:
                     pydicom.dcmread(file_path, stop_before_pixels=True)
                     return True
-                except:
+                except Exception:
                     return False
             elif self.backend == 'sitk' and SITK_AVAILABLE:
                 try:
@@ -260,9 +276,9 @@ class DicomTagPrinter:
                     reader.SetFileName(str(file_path))
                     reader.ReadImageInformation()
                     return True
-                except:
+                except Exception:
                     return False
-        except:
+        except Exception:
             pass
 
         return False
@@ -279,29 +295,13 @@ class DicomTagPrinter:
         Returns:
             List of .json file paths
         """
-        input_path = Path(input_path)
-        json_files = []
-
-        if input_path.is_file():
-            if input_path.suffix.lower() == '.json':
-                json_files.append(input_path)
-        elif input_path.is_dir():
-            if recursive:
-                try:
-                    dirs = recursive_list_dir(max_depth, str(input_path))
-                    for dir_path in dirs:
-                        for file_path in Path(dir_path).glob('*.json'):
-                            if file_path.is_file():
-                                json_files.append(file_path)
-                except Exception as e:
-                    self.logger.warning(f"Failed to use recursive_list_dir, using standard method: {e}")
-                    for file_path in input_path.rglob('*.json'):
-                        json_files.append(file_path)
-            else:
-                for file_path in input_path.glob('*.json'):
-                    json_files.append(file_path)
-
-        return sorted(json_files)
+        return self._find_files(
+            input_path,
+            lambda p: p.suffix.lower() == '.json',
+            '*.json',
+            recursive,
+            max_depth,
+        )
 
     # ------------------------------------------------------------------
     # Grouping & aggregation
@@ -386,7 +386,8 @@ class DicomTagPrinter:
                 result[tag] = values[0] if values else 'Missing'
                 continue
 
-            if len(set(valid)) == 1:
+            # Short-circuit: if all values are the same, no need to build a full set
+            if all(v == valid[0] for v in valid[1:]):
                 result[tag] = valid[0]
                 continue
 
@@ -414,7 +415,7 @@ class DicomTagPrinter:
                   the file are returned.
 
         Returns:
-            Dictionary mapping tag keys (or description strings) to their values.
+            Dictionary mapping tag keys to their values.
         """
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
@@ -493,7 +494,7 @@ class DicomTagPrinter:
             raise ImportError("pandas is required for build_dataframe. "
                               "Install it with: pip install pandas")
 
-        has_subject_id = results and 'SubjectID' in results[0]
+        has_subject_id = bool(results) and 'SubjectID' in results[0]
 
         if has_subject_id:
             index_cols = ['SubjectID', 'FileCount'] if group_by_series else ['SubjectID']
@@ -640,25 +641,24 @@ class DicomTagPrinter:
 
     def _print_table(self, df: 'pd.DataFrame') -> None:
         """Render the unified DataFrame as a rich table."""
-        if df.empty:
-            Console().print("[yellow]No results to display[/yellow]")
-            return
-
-        table = Table(show_header=True, header_style="bold magenta", show_lines=True)
-
-        for col in df.columns:
-            style = _COL_STYLES.get(col, _DEFAULT_TAG_STYLE)
-            table.add_column(col, **style)
-
-        for _, row in df.iterrows():
-            table.add_row(*[str(v) for v in row])
-
-        # Resolve console from logger's RichHandler if available
+        # Resolve console once; used for both empty and non-empty cases
         rich_handler = next(
             (h for h in self.logger._logger.handlers if isinstance(h, RichHandler)),
             None,
         )
         console = rich_handler.console if rich_handler else Console()
+
+        if df.empty:
+            console.print("[yellow]No results to display[/yellow]")
+            return
+
+        table = Table(show_header=True, header_style="bold magenta", show_lines=True)
+
+        for col in df.columns:
+            table.add_column(col, **_COL_STYLES.get(col, _DEFAULT_TAG_STYLE))
+
+        for row in df.itertuples(index=False, name=None):
+            table.add_row(*[str(v) for v in row])
 
         entity = 'series' if 'FileCount' in df.columns else 'files'
         console.print()
@@ -670,17 +670,9 @@ class DicomTagPrinter:
         if df.empty:
             print("# No results to display")
             return
-
-        print(','.join(df.columns))
-
-        for _, row in df.iterrows():
-            fields = []
-            for val in row:
-                val = str(val)
-                if ',' in val:
-                    val = f'"{val}"'
-                fields.append(val)
-            print(','.join(fields))
+        # Use pandas to_csv for correct RFC 4180 quoting (handles commas,
+        # embedded quotes, and newlines in values)
+        print(df.to_csv(index=False), end='')
 
     def _print_json(self, df: 'pd.DataFrame') -> None:
         """Print the unified DataFrame in JSON format."""

--- a/unit_test/test_dicom_tag_printer.py
+++ b/unit_test/test_dicom_tag_printer.py
@@ -869,7 +869,7 @@ class TestRealJsonSampleData(unittest.TestCase):
             self.assertIn("SubjectID", entry)
             # All sample files follow the subject_NNN naming scheme
             self.assertNotEqual(entry["SubjectID"], "N/A",
-                                msg=f"Failed to extract ID from {entry['FilePath']}")
+                                msg=f"Failed to extract ID from {entry.get('FilePath', entry.get('SubjectID', 'unknown'))}")
 
 
 @unittest.skipIf(_SKIP_NIFTI,

--- a/unit_test/test_dicom_tag_printer.py
+++ b/unit_test/test_dicom_tag_printer.py
@@ -687,14 +687,16 @@ class TestBuildDataframe(unittest.TestCase):
         self.assertEqual(df.iloc[0]['SeriesUID'], 'uid-1')
         self.assertEqual(df.iloc[0]['FileCount'], 10)
 
-    def test_subject_id_included_in_tag_cols(self):
-        """SubjectID from id_globber appears after index columns, before DICOM tags."""
+    def test_subject_id_replaces_filepath_as_index(self):
+        """When SubjectID is present it replaces FilePath as the primary index column."""
         results = [
             {'FilePath': '/a/NPC001.dcm', 'SubjectID': 'NPC001', '0008|0060': 'MR'},
         ]
-        df = self.printer.build_dataframe(results, ['SubjectID', '0008|0060'],
+        df = self.printer.build_dataframe(results, ['0008|0060'],
                                           group_by_series=False)
-        self.assertEqual(list(df.columns), ['FilePath', 'SubjectID', '0008|0060'])
+        # SubjectID is the index; FilePath is dropped from the output
+        self.assertEqual(list(df.columns), ['SubjectID', '0008|0060'])
+        self.assertEqual(df.iloc[0]['SubjectID'], 'NPC001')
 
     def test_missing_value_filled_with_na(self):
         """Keys absent from a result dict are filled with 'N/A'."""

--- a/unit_test/test_dicom_tag_printer.py
+++ b/unit_test/test_dicom_tag_printer.py
@@ -653,6 +653,152 @@ class TestIdGlobber(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# build_dataframe tests
+# ---------------------------------------------------------------------------
+
+class TestBuildDataframe(unittest.TestCase):
+    """Tests for the unified DicomTagPrinter.build_dataframe method."""
+
+    def setUp(self):
+        self.printer = DicomTagPrinter()
+
+    def test_file_view_columns(self):
+        """Non-series mode produces FilePath + tag columns in order."""
+        results = [
+            {'FilePath': '/a/1.dcm', '0008|0060': 'MR', '0010|0020': '001'},
+            {'FilePath': '/a/2.dcm', '0008|0060': 'CT', '0010|0020': '002'},
+        ]
+        df = self.printer.build_dataframe(results, ['0008|0060', '0010|0020'],
+                                          group_by_series=False)
+        self.assertEqual(list(df.columns), ['FilePath', '0008|0060', '0010|0020'])
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df.iloc[0]['FilePath'], '/a/1.dcm')
+        self.assertEqual(df.iloc[1]['0008|0060'], 'CT')
+
+    def test_series_view_columns(self):
+        """Series mode produces SeriesUID/FileCount/RepresentativeFile + tag columns."""
+        results = [
+            {'SeriesUID': 'uid-1', 'FileCount': 10, 'RepresentativeFile': '/a/1.dcm',
+             '0008|103e': 'T2'},
+        ]
+        df = self.printer.build_dataframe(results, ['0008|103e'], group_by_series=True)
+        self.assertEqual(list(df.columns),
+                         ['SeriesUID', 'FileCount', 'RepresentativeFile', '0008|103e'])
+        self.assertEqual(df.iloc[0]['SeriesUID'], 'uid-1')
+        self.assertEqual(df.iloc[0]['FileCount'], 10)
+
+    def test_subject_id_included_in_tag_cols(self):
+        """SubjectID from id_globber appears after index columns, before DICOM tags."""
+        results = [
+            {'FilePath': '/a/NPC001.dcm', 'SubjectID': 'NPC001', '0008|0060': 'MR'},
+        ]
+        df = self.printer.build_dataframe(results, ['SubjectID', '0008|0060'],
+                                          group_by_series=False)
+        self.assertEqual(list(df.columns), ['FilePath', 'SubjectID', '0008|0060'])
+
+    def test_missing_value_filled_with_na(self):
+        """Keys absent from a result dict are filled with 'N/A'."""
+        results = [{'FilePath': '/a/1.dcm', '0008|0060': 'MR'}]
+        df = self.printer.build_dataframe(results, ['0008|0060', '9999|9999'],
+                                          group_by_series=False)
+        self.assertEqual(df.iloc[0]['9999|9999'], 'N/A')
+
+    def test_no_duplicate_index_cols_when_tags_overlap(self):
+        """Index columns are never duplicated even if tags list contains them."""
+        results = [{'FilePath': '/a/1.dcm', '0008|0060': 'MR'}]
+        # Malformed tags list includes the index col name — must not duplicate it
+        df = self.printer.build_dataframe(results, ['FilePath', '0008|0060'],
+                                          group_by_series=False)
+        self.assertEqual(list(df.columns).count('FilePath'), 1)
+
+    def test_empty_results_returns_empty_dataframe(self):
+        """Empty results list produces a DataFrame with correct columns but no rows."""
+        df = self.printer.build_dataframe([], ['0008|0060'], group_by_series=False)
+        self.assertEqual(len(df), 0)
+        self.assertIn('FilePath', df.columns)
+        self.assertIn('0008|0060', df.columns)
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_series_tags tests
+# ---------------------------------------------------------------------------
+
+class TestAggregateSeriesTags(unittest.TestCase):
+    """Tests for DicomTagPrinter._aggregate_series_tags numeric summarisation."""
+
+    def setUp(self):
+        self.printer = DicomTagPrinter()
+
+    def _fake_read(self, values_by_tag):
+        """Return a side_effect list for read_dicom_tags calls.
+
+        *values_by_tag* maps tag -> list of values (one per simulated file).
+        """
+        n = max(len(v) for v in values_by_tag.values())
+        calls = []
+        for i in range(n):
+            calls.append({tag: vals[i] for tag, vals in values_by_tag.items()})
+        return calls
+
+    def test_identical_values_shown_once(self):
+        """Tags with the same value across all files show the single value."""
+        files = [Path('/s/1.dcm'), Path('/s/2.dcm'), Path('/s/3.dcm')]
+        side_effects = self._fake_read({'0008|103e': ['T2', 'T2', 'T2']})
+        with patch.object(self.printer, 'read_dicom_tags', side_effect=side_effects):
+            result = self.printer._aggregate_series_tags(files, ['0008|103e'])
+        self.assertEqual(result['0008|103e'], 'T2')
+
+    def test_integer_range_shown_as_min_tilde_max(self):
+        """Numeric tags that differ across files are shown as 'min~max'."""
+        files = [Path(f'/s/{i}.dcm') for i in range(5)]
+        values = [str(i + 1) for i in range(5)]  # '1' .. '5'
+        side_effects = self._fake_read({'0020|0013': values})
+        with patch.object(self.printer, 'read_dicom_tags', side_effect=side_effects):
+            result = self.printer._aggregate_series_tags(files, ['0020|0013'])
+        self.assertEqual(result['0020|0013'], '1~5')
+
+    def test_float_range_preserved(self):
+        """Non-integer float boundaries are shown with their decimal component."""
+        files = [Path('/s/1.dcm'), Path('/s/2.dcm')]
+        side_effects = self._fake_read({'0018|0050': ['2.5', '7.5']})
+        with patch.object(self.printer, 'read_dicom_tags', side_effect=side_effects):
+            result = self.printer._aggregate_series_tags(files, ['0018|0050'])
+        self.assertEqual(result['0018|0050'], '2.5~7.5')
+
+    def test_integer_boundaries_formatted_without_decimal(self):
+        """Integer-valued floats (e.g. 1.0) are shown without decimal point."""
+        files = [Path('/s/1.dcm'), Path('/s/2.dcm')]
+        side_effects = self._fake_read({'0020|0013': ['1.0', '30.0']})
+        with patch.object(self.printer, 'read_dicom_tags', side_effect=side_effects):
+            result = self.printer._aggregate_series_tags(files, ['0020|0013'])
+        self.assertEqual(result['0020|0013'], '1~30')
+
+    def test_non_numeric_mixed_uses_representative(self):
+        """Mixed non-numeric values fall back to the first file's value."""
+        files = [Path('/s/1.dcm'), Path('/s/2.dcm')]
+        side_effects = self._fake_read({'0008|103e': ['T2', 'DWI']})
+        with patch.object(self.printer, 'read_dicom_tags', side_effect=side_effects):
+            result = self.printer._aggregate_series_tags(files, ['0008|103e'])
+        self.assertEqual(result['0008|103e'], 'T2')
+
+    def test_all_missing_returns_missing(self):
+        """When all files report 'Missing', the aggregated value is 'Missing'."""
+        files = [Path('/s/1.dcm'), Path('/s/2.dcm')]
+        side_effects = self._fake_read({'9999|9999': ['Missing', 'Missing']})
+        with patch.object(self.printer, 'read_dicom_tags', side_effect=side_effects):
+            result = self.printer._aggregate_series_tags(files, ['9999|9999'])
+        self.assertEqual(result['9999|9999'], 'Missing')
+
+    def test_ignores_error_and_missing_sentinels_for_numeric(self):
+        """'Error'/'Missing' sentinels are excluded from numeric range computation."""
+        files = [Path('/s/1.dcm'), Path('/s/2.dcm'), Path('/s/3.dcm')]
+        side_effects = self._fake_read({'0020|0013': ['1', 'Missing', '10']})
+        with patch.object(self.printer, 'read_dicom_tags', side_effect=side_effects):
+            result = self.printer._aggregate_series_tags(files, ['0020|0013'])
+        self.assertEqual(result['0020|0013'], '1~10')
+
+
+# ---------------------------------------------------------------------------
 # Real sample data tests (skipped when files not present)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
This PR refactors the output handling in `DicomTagPrinter` to use a unified pandas DataFrame as the single source of truth for all output formats (table, CSV, JSON). It also adds support for aggregating numeric DICOM tags across all files in a series, showing value ranges instead of just the representative file's value.

## Key Changes

- **Unified DataFrame Architecture**: Introduced `build_dataframe()` method that creates a consistent DataFrame structure used by all output formatters (`_print_table`, `_print_csv`, `_print_json`). This ensures column ordering and structure are identical across all output formats.

- **Numeric Tag Aggregation**: Added `_aggregate_series_tags()` method that:
  - Reads all files in a series and aggregates tag values
  - Shows identical values as a single value
  - Displays numeric ranges as `"min~max"` format (e.g., `"1~30"`)
  - Falls back to the representative file's value for non-numeric mixed values
  - Properly handles 'Missing' and 'Error' sentinel values

- **New `summarize_numeric` Parameter**: Added optional parameter to `print_tags()` that enables numeric aggregation when grouping by series. Disabled by default since it requires reading every file in the series.

- **Pandas as Optional Dependency**: Added conditional pandas import with `TYPE_CHECKING` for type hints and runtime availability check. The `build_dataframe()` method raises a helpful error if pandas is not installed.

- **Refactored Output Methods**: 
  - `_print_results()` now dispatches a DataFrame instead of raw results
  - `_print_table()` uses DataFrame iteration and improved column styling
  - `_print_csv()` and `_print_json()` simplified to work with DataFrame
  - All methods now handle index columns (FilePath or SeriesUID/FileCount/RepresentativeFile) consistently

- **Code Quality**: Fixed trailing whitespace in docstrings throughout the file.

- **Comprehensive Tests**: Added 16 new unit tests covering:
  - DataFrame column structure for both file and series views
  - SubjectID integration with id_globber
  - Missing value handling
  - Numeric range aggregation with various data types
  - Edge cases (empty results, non-numeric mixed values, sentinel values)

## Implementation Details

The `build_dataframe()` method establishes the definitive column order: index columns first (FilePath or SeriesUID/FileCount/RepresentativeFile), followed by tag columns in the order specified. This ensures consistency across all output formats and prevents duplicate columns even if tags accidentally include index column names.

The numeric aggregation logic intelligently handles float formatting, showing `"1~30"` instead of `"1.0~30.0"` for integer-valued boundaries while preserving decimals for true floats like `"2.5~7.5"`.

https://claude.ai/code/session_016sMrUQZcDG2HTaHMCoMi59